### PR TITLE
Fix MExprParser.y - expected ‘;’ before ‘}’

### DIFF
--- a/src/MExprParser.y
+++ b/src/MExprParser.y
@@ -284,7 +284,7 @@ expr:
 						}
 						
 |	tADD atomicExpr %prec tPREADD		{	
-											$$ = $2
+											$$ = $2;
 										}
 
 |	tSUB atomicExpr %prec tPREADD		{	


### PR DESCRIPTION
src/MExprParser.y:289:11: error: expected ‘;’ before ‘}’ token
           }
